### PR TITLE
左寄せだったheaderの要素が中央に来るように調整

### DIFF
--- a/view/src/app/style.css
+++ b/view/src/app/style.css
@@ -44,7 +44,7 @@ header{
     font-size: 60px;
     float: left;
     text-align: center;
-    margin: 10px ;
+    margin: 10px 10px 10px 71px;
 
 }
 
@@ -54,7 +54,7 @@ header{
     width: 60%;
     float: left;
     text-align:left;
-    margin: 10px 10px;
+    margin: 10px 10px 10px 71px;
 
 }
 


### PR DESCRIPTION
## 目的
左寄せだったheaderの要素が中央に来るように調整

## 概要
- #siteTtlのmarginを10px -> 10px 10px 10px 71px
- #indexInfoのmarginを10px -> 10px 10px 10px 71px

## 確認項目
- [ ] http://localhost:3000/を開き、header内の要素が中央に来ていることを確認

## 不安・相談
